### PR TITLE
Fixed the case of function names.

### DIFF
--- a/autoload/ghp.vim
+++ b/autoload/ghp.vim
@@ -5,15 +5,15 @@ endif
 let s:save_cpo = &cpo
 set cpo&vim
 
-function! Ghp#Start() abort
+function! ghp#Start() abort
   python ghp.start()
 endfunction
 
-function! Ghp#Preview() abort
+function! ghp#Preview() abort
   python ghp.preview()
 endfunction
 
-function! Ghp#Stop() abort
+function! ghp#Stop() abort
   python ghp.stop()
 endfunction
 

--- a/plugin/ghp.vim
+++ b/plugin/ghp.vim
@@ -34,7 +34,7 @@ let g:ghp_open_browser = get(g:, 'ghp_open_browser', 1)
 
 " Perform disposal logic
 fu! s:dispose()
-    call Ghp#Stop()
+    call ghp#Stop()
 endfu
 
 " ------------------------------------------------------------------------------
@@ -43,11 +43,11 @@ endfu
 "
 " Prepare a buffer for being previewed
 fu! s:initBuffer()
-    call Ghp#Start()
+    call ghp#Start()
     aug ghp
         au! * <buffer>
-        au BufEnter <buffer> call Ghp#Preview()
-        au CursorHold,CursorHoldI,CursorMoved,CursorMovedI <buffer> call Ghp#Preview()
+        au BufEnter <buffer> call ghp#Preview()
+        au CursorHold,CursorHoldI,CursorMoved,CursorMovedI <buffer> call ghp#Preview()
     aug END
 endfu
 


### PR DESCRIPTION
The function names of the functions in autoload/ghp.vim are case sensitive in
Linux because they're bound to file names. The author probably didn't
experience breakage because [s]he uses macos or windows, which use
case-insenitive FSes.