### PR TITLE
Silences xdg-open output

### DIFF
--- a/python/ghp.py
+++ b/python/ghp.py
@@ -63,7 +63,7 @@ def start_browser(url):
          'open -g'  if sys.platform.startswith('darwin')\
     else 'start'    if sys.platform.startswith('win')\
     else 'xdg-open'
-    os.system(command + ' ' + url)
+    os.system(command + ' ' + url + ' ' + '> /dev/null 2>&1')
 
 
 def process_queue(stop_event, port, auto_open_browser, auto_start_server):


### PR DESCRIPTION
This fixes an issue I faced in Arch Linux which has a more up-to-date
version of fontconfig than what is statically shipped in Google Chrome.
When xdg-open executes, it spits out a ton of fontconfig errors which
clouds my VIM screen.

I don't see any reason why xdg-open stdout/stderr should ever present
itself to the VIM terminal, so this addition redirects all output to
`/dev/null`.